### PR TITLE
fix(scan): fix missing pages in scans.

### DIFF
--- a/scan.sh
+++ b/scan.sh
@@ -7,5 +7,10 @@ vendor=${vendor:-"fujitsu"}
 dpi=${dpi:-300}
 mode=${mode:-"Color"}
 
-# Run the scanning command
-/app/sane-scan-pdf/scan -v -d -x $vendor -r $dpi --mode $mode --skip-empty-pages -o /scans/$file_prefix-$now.pdf
+# Run the scanning command and save the output to a temporary file
+/app/sane-scan-pdf/scan -v -d -x $vendor -r $dpi --mode $mode --skip-empty-pages -o /tmp/$file_prefix-$now.pdf
+
+# Once the scan is complete, move the file to the output directory
+mv /tmp/$file_prefix-$now.pdf /scans/$file_prefix-$now.pdf
+
+# This is needed to ensure the file is ready to be imported by the next step.

--- a/scan.sh
+++ b/scan.sh
@@ -10,7 +10,18 @@ mode=${mode:-"Color"}
 # Run the scanning command and save the output to a temporary file
 /app/sane-scan-pdf/scan -v -d -x $vendor -r $dpi --mode $mode --skip-empty-pages -o /tmp/$file_prefix-$now.pdf
 
+if [ $? -ne 0 ]; then
+    echo "Error: Scan command failed. Exiting."
+    exit 1
+fi
+
 # Once the scan is complete, move the file to the output directory
+echo "Scan completed successfully. Moving file to /scans/$file_prefix-$now.pdf"
 mv /tmp/$file_prefix-$now.pdf /scans/$file_prefix-$now.pdf
+
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to move the file to /scans. Please check permissions or directory existence." >&2
+    exit 1
+fi
 
 # This is needed to ensure the file is ready to be imported by the next step.


### PR DESCRIPTION
In this PR:

- Writing directly to the output folder, confuses the the ingestion services as these files are not complete yet.
- Instead create a PDF in `tmp` and move to `scans` folder after.